### PR TITLE
make plot code compatible with new ggplot version

### DIFF
--- a/R/commonDiscoverDistributions.R
+++ b/R/commonDiscoverDistributions.R
@@ -537,7 +537,7 @@
 }
 
 .ldFillQQPlot <- function(qqplot, estParameters, options, variable){
-  p <- ggplot2::ggplot(data = NULL, ggplot2::aes(sample = variable)) +
+  p <- ggplot2::ggplot(data = data.frame(variable = variable), ggplot2::aes(sample = variable)) +
     ggplot2::stat_qq(distribution = options[['qFun']], dparams = estParameters, shape = 21, fill = "grey", size = 3) +
     ggplot2::stat_qq_line(distribution = options[['qFun']], dparams = estParameters) +
     ggplot2::xlab(gettext("Theoretical")) + ggplot2::ylab(gettext("Sample")) +
@@ -551,7 +551,7 @@
 }
 
 .ldFillEstPDFPlot <- function(pdfplot, estParameters, options, variable){
-  p <- ggplot2::ggplot(data = NULL, ggplot2::aes(x = variable)) +
+  p <- ggplot2::ggplot(data = data.frame(variable = variable), ggplot2::aes(x = variable)) +
     ggplot2::geom_histogram(ggplot2::aes(y = ..density..), fill = "grey", col = "black") +
     ggplot2::stat_function(fun = options[['pdfFun']], args = as.list(estParameters), size = 1.5) + 
     ggplot2::geom_rug() +
@@ -597,7 +597,7 @@
   args[['q']] <- variable
   TheoreticalProp <- sort(do.call(options[['cdfFun']], args))
   
-  p <- ggplot2::ggplot(data = NULL) +
+  p <- ggplot2::ggplot(data = data.frame(TheoreticalProp = TheoreticalProp, ObservedProp = ObservedProp)) +
     ggplot2::geom_abline(slope = 1, intercept = 0) +
     jaspGraphs::geom_point(ggplot2::aes(x = TheoreticalProp, y = ObservedProp)) +
     ggplot2::xlab(gettext("Theoretical")) + ggplot2::ylab(gettext("Sample")) +
@@ -612,7 +612,7 @@
 }
 
 .ldFillEstCDFPlot <- function(cdfplot, estParameters, options, variable){
-  p <- ggplot2::ggplot(data = NULL, ggplot2::aes(x = variable)) +
+  p <- ggplot2::ggplot(data = data.frame(variable = variable), ggplot2::aes(x = variable)) +
     ggplot2::stat_ecdf(geom = "step") +
     ggplot2::geom_rug() +
     ggplot2::stat_function(fun = options[['cdfFun']], args = as.list(estParameters), size = 1.5) + 
@@ -1303,7 +1303,7 @@
 }
 
 .ldFillPlotECDF <- function(plot, options, variable){
-  p <- ggplot2::ggplot(data = NULL, ggplot2::aes(x = variable)) +
+  p <- ggplot2::ggplot(data = data.frame(variable = variable), ggplot2::aes(x = variable)) +
     ggplot2::stat_ecdf(geom = "step", size = 1.5) +
     ggplot2::geom_rug() +
     ggplot2::scale_x_continuous(limits = range(variable)*1.1) +


### PR DESCRIPTION
Consider this example (basically `.ldFillPlotECDF`):

```r
var <- c(0.0418017450720072, 0.253578857053071, 0.55308344354853, 0.845950480550528, 
         0.55389997549355, 0.486004799371585, 0.718396389158443, 0.707887368742377, 
         0.442777341464534, 0.837313188705593, 0.335892906412482, 0.129563027760014, 
         0.770009979140013, 0.036876525497064, 0.632003614213318, 0.0645552300848067, 
         0.288439290132374, 0.0164910017047077, 0.8408905249089, 0.795341055141762, 
         0.765119842253625, 0.579402944538742, 0.254531836370006, 0.55490576243028, 
         0.592439631931484, 0.211427065078169, 0.261550485156477, 0.895902385236696, 
         0.361128017073497, 0.638278447091579, 0.21299664536491, 0.901881573023275, 
         0.209907856304199, 0.00572087755426764, 0.374174808850512, 0.79237997927703, 
         0.167537066852674, 0.401040053693578, 0.0604952913708985, 0.187784455949441, 
         0.32407789118588, 0.817616889951751, 0.00036665378138423, 0.281237574992701, 
         0.690607686527073, 0.314882405567914, 0.432107519824058, 0.502697950927541, 
         0.147699516266584, 0.0598645892459899, 0.281792119378224, 0.670248746639118, 
         0.556962204631418, 0.72577631380409, 0.315112632699311, 0.716941306600347, 
         0.992230934556574, 0.979844438610598, 0.757509068353102, 0.976159062702209, 
         0.512629992561415, 0.0101763475686312, 0.0678008852992207, 0.265024271095172, 
         0.638881172752008, 0.113632942782715, 0.501247946638614, 0.0333501601126045, 
         0.799693877110258, 0.290657941019163, 0.799707227153704, 0.252563308458775, 
         0.132026514504105, 0.906751474598423, 0.300418253289536, 0.0510227505583316, 
         0.257587410742417, 0.449718851363286, 0.277429205132648, 0.566404427634552, 
         0.197679673787206, 0.548250997904688, 0.285596492001787, 0.309016948100179, 
         0.740303033962846, 0.0388873890042305, 0.90943190199323, 0.549529295647517, 
         0.991461722878739, 0.212786031886935, 0.237147178733721, 0.912062474992126, 
         0.794622871093452, 0.00839880807325244, 0.648492358159274, 0.683792835567147, 
         0.152150738751516, 0.382500931154937, 0.158779360819608, 0.0657351815607399
)

opts <- list(
  cdfFun = stats::pbeta,
  variable = "Beta100(alpha=1,beta=1)"
)

est <- c(shape1 = 0.796710300302522, shape2 = 1.0027432430584)

old <- function(estParameters, options, variable){

  p <- ggplot2::ggplot(NULL, ggplot2::aes(x = variable)) +
    ggplot2::stat_ecdf(geom = "step") +
    ggplot2::geom_rug() +
    ggplot2::stat_function(fun = options[['cdfFun']], args = as.list(estParameters), size = 1.5) + 
    ggplot2::scale_x_continuous(limits = range(variable), breaks = pretty(range(variable))) +
    ggplot2::scale_y_continuous(limits = 0:1) + 
    ggplot2::ylab(substitute(p~(X <= x), list(p = gettext("Probability")))) +
    ggplot2::xlab(options[['variable']])
  
  return(p)
}

new <- function(estParameters, options, variable){

  p <- ggplot2::ggplot(data = data.frame(variable = variable), ggplot2::aes(x = variable)) +
    ggplot2::stat_ecdf(geom = "step") +
    ggplot2::geom_rug() +
    ggplot2::stat_function(fun = options[['cdfFun']], args = as.list(estParameters), size = 1.5) + 
    ggplot2::scale_x_continuous(limits = range(variable), breaks = pretty(range(variable))) +
    ggplot2::scale_y_continuous(limits = 0:1) + 
    ggplot2::ylab(substitute(p~(X <= x), list(p = gettext("Probability")))) +
    ggplot2::xlab(options[['variable']])
  
  return(p)
}
```
Calling
```r
old(est, opts, var)
new(est, opts, var)
```
shows that `old` (the code on master) fails with the latest ggplot version (3.3.2) whereas `new` (this PR) does not.
