### PR TITLE
Distributions are more friendly without data, and produce fit assessment if the user did not estimate parameters

### DIFF
--- a/R/commonDiscoverDistributions.R
+++ b/R/commonDiscoverDistributions.R
@@ -376,7 +376,10 @@
 ### MLE stuff ----
 .ldMLE <- function(jaspResults, variable, options, ready, errors, fillTable, ...){
   ready <- ready && isFALSE(errors)
-  if(! options$methodMLE) return()
+  # override MLE option if any assess fit method is requested
+  options[["methodMLE"]] <- options[["methodMLE"]] || .ldAnyAssessFitRequested(options)
+  # jump out if mle not desired
+  if(!options[["methodMLE"]]) return()
   
   mleContainer <- .ldGetFitContainer(jaspResults, options, "mleContainer", gettext("Maximum likelihood"), 7, errors)
     
@@ -395,6 +398,19 @@
   # fit plots
   .ldFitPlots(mleFitContainer, mleResults$fitdist$estimate, options, variable, ready)
 }
+
+.ldAnyAssessFitRequested <- function(options) {
+  isTRUE(options[["kolmogorovSmirnov"]]) ||
+  isTRUE(options[["cramerVonMisses"]]) ||
+  isTRUE(options[["andersonDarling"]]) ||
+  isTRUE(options[["shapiroWilk"]]) ||
+  isTRUE(options[["chiSquare"]]) ||
+  isTRUE(options[["estPDF"]]) ||
+  isTRUE(options[["estPMF"]]) ||
+  isTRUE(options[["estCDF"]]) ||
+  isTRUE(options[["qqplot"]]) ||
+  isTRUE(options[["ppplot"]])
+} 
 
 .ldMLEResults <- function(mleContainer, variable, options, ready, distName){
   if(!ready) return()

--- a/inst/qml/LDbernoulli.qml
+++ b/inst/qml/LDbernoulli.qml
@@ -95,19 +95,5 @@ Form
 
 	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-	Section
-	{
-		title: qsTr("Assess Fit")
-		enabled: mainWindow.dataAvailable
-
-		Group
-		{
-			title: qsTr("Plots")
-			columns: 1
-			CheckBox{ name: "estPMF"; label: qsTr("Histogram vs. theoretical pmf") }
-			CheckBox{ name: "qqplot"; label: qsTr("Q-Q plot"); visible: false      }
-			CheckBox{ name: "estCDF"; label: qsTr("Empirical vs. theoretical cdf") }
-			CheckBox{ name: "ppplot"; label: qsTr("P-P plot")                      }
-		}
-	}
+	LD.LDAssessFit { enabled: mainWindow.dataAvailable; distributionType: "categorical" }
 }

--- a/inst/qml/LDbernoulli.qml
+++ b/inst/qml/LDbernoulli.qml
@@ -93,36 +93,8 @@ Form
 		enabled						: mainWindow.dataAvailable
 	}
 
-	Section
-	{
-		title: qsTr("Estimate Parameters")
-		enabled: mainWindow.dataAvailable
+	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-		Group
-		{
-			CheckBox{ name: "methodMLE";      label: qsTr("Maximum likelihood"); visible: true  }
-			CheckBox{ name: "methodMoments";  label: qsTr("Method of moments");  visible: false }
-			CheckBox{ name: "methodUnbiased"; label: qsTr("Unbiased estimator"); visible: false }
-		}
-
-		Group
-		{
-			title: qsTr("Output")
-			CheckBox
-			{
-				name: "outputEstimates"; label: qsTr("Estimates"); checked: true
-				CheckBox{ name: "outputSE"; label: qsTr("Std. error"); checked: false }
-				CheckBox
-				{
-					name: "ciInterval"; label: qsTr("Confidence interval"); childrenOnSameRow: true
-					PercentField{ name: "ciIntervalInterval"; label: ""; defaultValue: 95 }
-				}
-			}
-
-			CheckBox{ name: "outputVarCov"; label: qsTr("Variance-covariance"); checked: false; visible: false }
-			CheckBox{ name: "outputCor";    label: qsTr("Correlation"); checked: false; visible: false }
-		}
-	}
 	Section
 	{
 		title: qsTr("Assess Fit")

--- a/inst/qml/LDbeta.qml
+++ b/inst/qml/LDbeta.qml
@@ -73,29 +73,5 @@ Form
 
 	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-	Section
-	{
-		title: qsTr("Assess Fit")
-		enabled: mainWindow.dataAvailable
-
-		Group
-		{
-			title: qsTr("Plots")
-			columns: 2
-			CheckBox{ name: "estPDF"; label: qsTr("Histogram vs. theoretical pdf") }
-			CheckBox{ name: "qqplot"; label: qsTr("Q-Q plot")                      }
-			CheckBox{ name: "estCDF"; label: qsTr("Empirical vs. theoretical cdf") }
-			CheckBox{ name: "ppplot"; label: qsTr("P-P plot")                      }
-		}
-
-		Group
-		{
-			title: qsTr("Statistics")
-			CheckBox{ name: "kolmogorovSmirnov";  label: qsTr("Kolmogorov-Smirnov")}
-			CheckBox{ name: "cramerVonMisses";    label: qsTr("Cramér–von Mises")  }
-			CheckBox{ name: "andersonDarling";    label: qsTr("Anderson-Darling")  }
-			//CheckBox{ name: "shapiroWilk";        label: qsTr("Shapiro-Wilk")      }
-		}
-
-	}
+	LD.LDAssessFit { enabled: mainWindow.dataAvailable }
 }

--- a/inst/qml/LDbeta.qml
+++ b/inst/qml/LDbeta.qml
@@ -71,36 +71,8 @@ Form
 		enabled				: mainWindow.dataAvailable
 	}
 
-	Section
-	{
-		title: qsTr("Estimate Parameters")
-		enabled: mainWindow.dataAvailable
+	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-		Group
-		{
-			CheckBox{ name: "methodMLE";      label: qsTr("Maximum likelihood"); visible: true  }
-			CheckBox{ name: "methodMoments";  label: qsTr("Method of moments");  visible: false }
-			CheckBox{ name: "methodUnbiased"; label: qsTr("Unbiased estimator"); visible: false }
-		}
-
-		Group
-		{
-			title: qsTr("Output")
-			CheckBox
-			{
-				name: "outputEstimates"; label: qsTr("Estimates"); checked: true
-				CheckBox{ name: "outputSE"; label: qsTr("Std. error"); checked: false }
-				CheckBox
-				{
-					name: "ciInterval"; label: qsTr("Confidence interval"); childrenOnSameRow: true
-					PercentField{ name: "ciIntervalInterval"; label: ""; defaultValue: 95 }
-				}
-			}
-
-			CheckBox{ name: "outputVarCov"; label: qsTr("Variance-covariance"); checked: false; visible: false }
-			CheckBox{ name: "outputCor";    label: qsTr("Correlation"); checked: false; visible: false }
-		}
-	}
 	Section
 	{
 		title: qsTr("Assess Fit")

--- a/inst/qml/LDbinomial.qml
+++ b/inst/qml/LDbinomial.qml
@@ -111,36 +111,8 @@ Form
 		enabled					: mainWindow.dataAvailable
 	}
 
-	Section
-	{
-		title: qsTr("Estimate Parameters")
-		enabled: mainWindow.dataAvailable
+	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-		Group
-		{
-			CheckBox{ name: "methodMLE";      label: qsTr("Maximum likelihood"); visible: true  }
-			CheckBox{ name: "methodMoments";  label: qsTr("Method of moments");  visible: false }
-			CheckBox{ name: "methodUnbiased"; label: qsTr("Unbiased estimator"); visible: false }
-		}
-
-		Group
-		{
-			title: qsTr("Output")
-			CheckBox
-			{
-				name: "outputEstimates"; label: qsTr("Estimates"); checked: true
-				CheckBox{ name: "outputSE"; label: qsTr("Std. error"); checked: false }
-				CheckBox
-				{
-					name: "ciInterval"; label: qsTr("Confidence interval"); childrenOnSameRow: true
-					PercentField{ name: "ciIntervalInterval"; label: ""; defaultValue: 95 }
-				}
-			}
-
-			CheckBox{ name: "outputVarCov"; label: qsTr("Variance-covariance"); checked: false; visible: false }
-			CheckBox{ name: "outputCor";    label: qsTr("Correlation"); checked: false; visible: false }
-		}
-	}
 	Section
 	{
 		title: qsTr("Assess Fit")

--- a/inst/qml/LDbinomial.qml
+++ b/inst/qml/LDbinomial.qml
@@ -113,30 +113,5 @@ Form
 
 	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-	Section
-	{
-		title: qsTr("Assess Fit")
-		enabled: mainWindow.dataAvailable
-
-		Group
-		{
-			title: qsTr("Plots")
-			columns: 2
-			CheckBox{ name: "estPMF"; label: qsTr("Histogram vs. theoretical pmf") }
-			CheckBox{ name: "qqplot"; label: qsTr("Q-Q plot")                      }
-			CheckBox{ name: "estCDF"; label: qsTr("Empirical vs. theoretical cdf") }
-			CheckBox{ name: "ppplot"; label: qsTr("P-P plot")                      }
-		}
-
-		Group
-		{
-			title: qsTr("Statistics")
-			//CheckBox{ name: "kolmogorovSmirnov";  label: qsTr("Kolmogorov-Smirnov")}
-			//CheckBox{ name: "cramerVonMisses";    label: qsTr("Cramér–von Mises")  }
-			//CheckBox{ name: "andersonDarling";    label: qsTr("Anderson-Darling")  }
-			//CheckBox{ name: "shapiroWilk";        label: qsTr("Shapiro-Wilk")      }
-			CheckBox{ name: "chiSquare"; label: qsTr("Chi-square")}
-		}
-
-	}
+	LD.LDAssessFit { enabled: mainWindow.dataAvailable; distributionType: "counts" }
 }

--- a/inst/qml/LDchisq.qml
+++ b/inst/qml/LDchisq.qml
@@ -74,36 +74,8 @@ Form
 		enabled					: mainWindow.dataAvailable
 	}
 
-	Section
-	{
-		title: qsTr("Estimate Parameters")
-		enabled: mainWindow.dataAvailable
+	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-		Group
-		{
-			CheckBox{ name: "methodMLE";      label: qsTr("Maximum likelihood"); visible: true  }
-			//CheckBox{ name: "methodMoments";  label: qsTr("Method of moments");  visible: false }
-			//CheckBox{ name: "methodUnbiased"; label: qsTr("Unbiased estimator"); visible: false }
-		}
-
-		Group
-		{
-			title: qsTr("Output")
-			CheckBox
-			{
-				name: "outputEstimates"; label: qsTr("Estimates"); checked: true
-				CheckBox{ name: "outputSE"; label: qsTr("Std. error"); checked: false }
-				CheckBox
-				{
-					name: "ciInterval"; label: qsTr("Confidence interval"); childrenOnSameRow: true
-					PercentField{ name: "ciIntervalInterval"; label: ""; defaultValue: 95 }
-				}
-			}
-
-			CheckBox{ name: "outputVarCov"; label: qsTr("Variance-covariance"); checked: false; visible: false }
-			CheckBox{ name: "outputCor";    label: qsTr("Correlation"); checked: false; visible: false }
-		}
-	}
 	Section
 	{
 		title: qsTr("Assess Fit")

--- a/inst/qml/LDchisq.qml
+++ b/inst/qml/LDchisq.qml
@@ -76,29 +76,5 @@ Form
 
 	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-	Section
-	{
-		title: qsTr("Assess Fit")
-		enabled: mainWindow.dataAvailable
-
-		Group
-		{
-			title: qsTr("Plots")
-			columns: 2
-			CheckBox{ name: "estPDF"; label: qsTr("Histogram vs. theoretical pdf") }
-			CheckBox{ name: "qqplot"; label: qsTr("Q-Q plot")                      }
-			CheckBox{ name: "estCDF"; label: qsTr("Empirical vs. theoretical cdf") }
-			CheckBox{ name: "ppplot"; label: qsTr("P-P plot")                      }
-		}
-
-		Group
-		{
-			title: qsTr("Statistics")
-			CheckBox{ name: "kolmogorovSmirnov";  label: qsTr("Kolmogorov-Smirnov")}
-			CheckBox{ name: "cramerVonMisses";    label: qsTr("Cramér–von Mises")  }
-			CheckBox{ name: "andersonDarling";    label: qsTr("Anderson-Darling")  }
-			//CheckBox{ name: "shapiroWilk";        label: qsTr("Shapiro-Wilk")      }
-		}
-
-	}
+	LD.LDAssessFit { enabled: mainWindow.dataAvailable }
 }

--- a/inst/qml/LDexponential.qml
+++ b/inst/qml/LDexponential.qml
@@ -82,36 +82,8 @@ Form
 		enabled					: mainWindow.dataAvailable
 	}
 
-	Section
-	{
-		title: qsTr("Estimate Parameters")
-		enabled: mainWindow.dataAvailable
+	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-		Group
-		{
-			CheckBox{ name: "methodMLE";      label: qsTr("Maximum likelihood"); visible: true  }
-			CheckBox{ name: "methodMoments";  label: qsTr("Method of moments");  visible: false }
-			CheckBox{ name: "methodUnbiased"; label: qsTr("Unbiased estimator"); visible: false }
-		}
-
-		Group
-		{
-			title: qsTr("Output")
-			CheckBox
-			{
-				name: "outputEstimates"; label: qsTr("Estimates"); checked: true
-				CheckBox{ name: "outputSE"; label: qsTr("Std. error"); checked: false }
-				CheckBox
-				{
-					name: "ciInterval"; label: qsTr("Confidence interval"); childrenOnSameRow: true
-					PercentField{ name: "ciIntervalInterval"; label: ""; defaultValue: 95 }
-				}
-			}
-
-			CheckBox{ name: "outputVarCov"; label: qsTr("Variance-covariance"); checked: false; visible: false }
-			CheckBox{ name: "outputCor";    label: qsTr("Correlation"); checked: false; visible: false }
-		}
-	}
 	Section
 	{
 		title: qsTr("Assess Fit")

--- a/inst/qml/LDexponential.qml
+++ b/inst/qml/LDexponential.qml
@@ -84,28 +84,5 @@ Form
 
 	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-	Section
-	{
-		title: qsTr("Assess Fit")
-		enabled: mainWindow.dataAvailable
-
-		Group
-		{
-			title: qsTr("Plots")
-			columns: 2
-			CheckBox{ name: "estPDF"; label: qsTr("Histogram vs. theoretical pdf") }
-			CheckBox{ name: "qqplot"; label: qsTr("Q-Q plot")                      }
-			CheckBox{ name: "estCDF"; label: qsTr("Empirical vs. theoretical cdf") }
-			CheckBox{ name: "ppplot"; label: qsTr("P-P plot")                      }
-		}
-
-		Group
-		{
-			title: qsTr("Statistics")
-			CheckBox{ name: "kolmogorovSmirnov";  label: qsTr("Kolmogorov-Smirnov")}
-			CheckBox{ name: "cramerVonMisses";    label: qsTr("Cramér–von Mises")  }
-			CheckBox{ name: "andersonDarling";    label: qsTr("Anderson-Darling")  }
-		}
-
-	}
+	LD.LDAssessFit { enabled: mainWindow.dataAvailable }
 }

--- a/inst/qml/LDf.qml
+++ b/inst/qml/LDf.qml
@@ -74,36 +74,7 @@ Form
 		enabled					: mainWindow.dataAvailable
 	}
 
-	Section
-	{
-		title: qsTr("Estimate Parameters")
-		enabled: mainWindow.dataAvailable
-
-		Group
-		{
-			CheckBox{ name: "methodMLE";      label: qsTr("Maximum likelihood"); visible: true  }
-			//CheckBox{ name: "methodMoments";  label: qsTr("Method of moments");  visible: false }
-			//CheckBox{ name: "methodUnbiased"; label: qsTr("Unbiased estimator"); visible: false }
-		}
-
-		Group
-		{
-			title: qsTr("Output")
-			CheckBox
-			{
-				name: "outputEstimates"; label: qsTr("Estimates"); checked: true
-				CheckBox{ name: "outputSE"; label: qsTr("Std. error"); checked: false }
-				CheckBox
-				{
-					name: "ciInterval"; label: qsTr("Confidence interval"); childrenOnSameRow: true
-					PercentField{ name: "ciIntervalInterval"; label: ""; defaultValue: 95 }
-				}
-			}
-
-			CheckBox{ name: "outputVarCov"; label: qsTr("Variance-covariance"); checked: false; visible: false }
-			CheckBox{ name: "outputCor";    label: qsTr("Correlation"); checked: false; visible: false }
-		}
-	}
+	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
 	Section
 	{

--- a/inst/qml/LDf.qml
+++ b/inst/qml/LDf.qml
@@ -76,29 +76,5 @@ Form
 
 	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-	Section
-	{
-		title: qsTr("Assess Fit")
-		enabled: mainWindow.dataAvailable
-
-		Group
-		{
-			title: qsTr("Plots")
-			columns: 2
-			CheckBox{ name: "estPDF"; label: qsTr("Histogram vs. theoretical pdf") }
-			CheckBox{ name: "qqplot"; label: qsTr("Q-Q plot")                      }
-			CheckBox{ name: "estCDF"; label: qsTr("Empirical vs. theoretical cdf") }
-			CheckBox{ name: "ppplot"; label: qsTr("P-P plot")                      }
-		}
-
-		Group
-		{
-			title: qsTr("Statistics")
-			CheckBox{ name: "kolmogorovSmirnov";  label: qsTr("Kolmogorov-Smirnov")}
-			CheckBox{ name: "cramerVonMisses";    label: qsTr("Cramér–von Mises")  }
-			CheckBox{ name: "andersonDarling";    label: qsTr("Anderson-Darling")  }
-			//CheckBox{ name: "shapiroWilk";        label: qsTr("Shapiro-Wilk")      }
-		}
-
-	}
+	LD.LDAssessFit { enabled: mainWindow.dataAvailable }
 }

--- a/inst/qml/LDgamma.qml
+++ b/inst/qml/LDgamma.qml
@@ -100,29 +100,5 @@ Form
 
 	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-	Section
-	{
-		title: qsTr("Assess Fit")
-		enabled: mainWindow.dataAvailable
-
-		Group
-		{
-			title: qsTr("Plots")
-			columns: 2
-			CheckBox{ name: "estPDF"; label: qsTr("Histogram vs. theoretical pdf") }
-			CheckBox{ name: "qqplot"; label: qsTr("Q-Q plot")                      }
-			CheckBox{ name: "estCDF"; label: qsTr("Empirical vs. theoretical cdf") }
-			CheckBox{ name: "ppplot"; label: qsTr("P-P plot")                      }
-		}
-
-		Group
-		{
-			title: qsTr("Statistics")
-			CheckBox{ name: "kolmogorovSmirnov";  label: qsTr("Kolmogorov-Smirnov")}
-			CheckBox{ name: "cramerVonMisses";    label: qsTr("Cramér–von Mises")  }
-			CheckBox{ name: "andersonDarling";    label: qsTr("Anderson-Darling")  }
-			//CheckBox{ name: "shapiroWilk";        label: qsTr("Shapiro-Wilk")      }
-		}
-
-	}
+	LD.LDAssessFit { enabled: mainWindow.dataAvailable }
 }

--- a/inst/qml/LDgamma.qml
+++ b/inst/qml/LDgamma.qml
@@ -98,36 +98,8 @@ Form
 		enabled					: mainWindow.dataAvailable
 	}
 
-	Section
-	{
-		title: qsTr("Estimate Parameters")
-		enabled: mainWindow.dataAvailable
+	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-		Group
-		{
-			CheckBox{ name: "methodMLE";      label: qsTr("Maximum likelihood"); visible: true  }
-			CheckBox{ name: "methodMoments";  label: qsTr("Method of moments");  visible: false }
-			CheckBox{ name: "methodUnbiased"; label: qsTr("Unbiased estimator"); visible: false }
-		}
-
-		Group
-		{
-			title: qsTr("Output")
-			CheckBox
-			{
-				name: "outputEstimates"; label: qsTr("Estimates"); checked: true
-				CheckBox{ name: "outputSE"; label: qsTr("Std. error"); checked: false }
-				CheckBox
-				{
-					name: "ciInterval"; label: qsTr("Confidence interval"); childrenOnSameRow: true
-					PercentField{ name: "ciIntervalInterval"; label: ""; defaultValue: 95 }
-				}
-			}
-
-			CheckBox{ name: "outputVarCov"; label: qsTr("Variance-covariance"); checked: false; visible: false }
-			CheckBox{ name: "outputCor";    label: qsTr("Correlation"); checked: false; visible: false }
-		}
-	}
 	Section
 	{
 		title: qsTr("Assess Fit")

--- a/inst/qml/LDgammaInverse.qml
+++ b/inst/qml/LDgammaInverse.qml
@@ -99,36 +99,8 @@ Form
 		enabled					: mainWindow.dataAvailable
 	}
 
-	Section
-	{
-		title: qsTr("Estimate Parameters")
-		enabled: mainWindow.dataAvailable
+	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-		Group
-		{
-			CheckBox{ name: "methodMLE";      label: qsTr("Maximum likelihood"); visible: true  }
-			CheckBox{ name: "methodMoments";  label: qsTr("Method of moments");  visible: false }
-			CheckBox{ name: "methodUnbiased"; label: qsTr("Unbiased estimator"); visible: false }
-		}
-
-		Group
-		{
-			title: qsTr("Output")
-			CheckBox
-			{
-				name: "outputEstimates"; label: qsTr("Estimates"); checked: true
-				CheckBox{ name: "outputSE"; label: qsTr("Std. error"); checked: false }
-				CheckBox
-				{
-					name: "ciInterval"; label: qsTr("Confidence interval"); childrenOnSameRow: true
-					PercentField{ name: "ciIntervalInterval"; label: ""; defaultValue: 95 }
-				}
-			}
-
-			CheckBox{ name: "outputVarCov"; label: qsTr("Variance-covariance"); checked: false; visible: false }
-			CheckBox{ name: "outputCor";    label: qsTr("Correlation"); checked: false; visible: false }
-		}
-	}
 	Section
 	{
 		title: qsTr("Assess Fit")

--- a/inst/qml/LDgaussianunivariate.qml
+++ b/inst/qml/LDgaussianunivariate.qml
@@ -99,63 +99,8 @@ Form
 		enabled					: mainWindow.dataAvailable
 	}
 
-	Section
-	{
-		title: qsTr("Estimate Parameters")
-		enabled: mainWindow.dataAvailable
+	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-		Group
-		{
-			title: ""
-			CheckBox{ name: "methodMLE";      label: qsTr("Maximum likelihood")}
-			CheckBox{ name: "methodMoments";  label: qsTr("Method of moments") ; visible: false}
-			CheckBox{ name: "methodUnbiased"; label: qsTr("Unbiased estimator"); visible: false}
-			//CheckBox
-			//{
-			//   name: "methodML";      label: qsTr("Maximum Likelihood"); debug: true
-			//    Group{
-			//        CheckBox{ name: "methodMLAnalytic"; label: qsTr("Analytic")    }
-			//        CheckBox{ name: "methodMLNewton";   label: qsTr("Newton")      }
-			//        CheckBox{ name: "methodMLGrid";     label: qsTr("Grid search") }
-			//    }
-			//}
-			//CheckBox
-			//{
-			//    name: "methodBayes";   label: qsTr("Bayesian"); debug: true
-			//   Group{
-			//        CheckBox{ name: "methodBayesAnalytic"; label: qsTr("Analytic") }
-			//        CheckBox{ name: "methodBayesMAP";      label: qsTr("Maximum a posteriori") }
-			//        CheckBox{ name: "methodBayesGibbs";    label: qsTr("Gibbs sampling") }
-			//    }
-			//    Group{title: qsTr("Priors")}
-			//}
-		}
-
-		Group
-		{
-			title: qsTr("Output")
-			debug: false
-			CheckBox{ name: "outputEstimates"; label: qsTr("Estimates"); checked: true
-				CheckBox{ name: "outputSE"; label: qsTr("Std. error"); checked: false}
-				CheckBox
-				{
-					name: "ciInterval"; label: qsTr("Confidence interval"); childrenOnSameRow: true
-					PercentField{ name: "ciIntervalInterval"; label: ""; defaultValue: 95}
-				}
-			}
-
-			CheckBox{ name: "outputVarCov"; label: qsTr("Variance-covariance"); checked: false; visible: false}
-			CheckBox{ name: "outputCor";    label: qsTr("Correlation"); checked: false; visible: false}
-
-			//Group{
-			//    debug: true
-			//    title: qsTr("Plots")
-			//    CheckBox{ name: "plotEstimates";   label: qsTr("Estimates")   }
-			//    CheckBox{ name: "plotDiagnostics"; label: qsTr("Diagnostics") }
-			//    CheckBox{ name: "plotAdvanced";    label: qsTr("Advanced")    }
-			//}
-		}
-	}
 	Section
 	{
 		title: qsTr("Assess Fit")

--- a/inst/qml/LDgaussianunivariate.qml
+++ b/inst/qml/LDgaussianunivariate.qml
@@ -101,28 +101,5 @@ Form
 
 	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-	Section
-	{
-		title: qsTr("Assess Fit")
-		enabled: mainWindow.dataAvailable
-
-		Group
-		{
-			title: qsTr("Plots")
-			columns: 2
-			CheckBox{ name: "estPDF"; label: qsTr("Histogram vs. theoretical pdf") }
-			CheckBox{ name: "qqplot"; label: qsTr("Q-Q plot")}
-			CheckBox{ name: "estCDF"; label: qsTr("Empirical vs. theoretical cdf") }
-			CheckBox{ name: "ppplot"; label: qsTr("P-P plot")}
-		}
-
-		Group
-		{
-			title: qsTr("Statistics")
-			CheckBox{ name: "kolmogorovSmirnov"; label: qsTr("Kolmogorov-Smirnov")}
-			CheckBox{ name: "cramerVonMisses";   label: qsTr("Cramér–von Mises")  }
-			CheckBox{ name: "andersonDarling";   label: qsTr("Anderson-Darling")  }
-			CheckBox{ name: "shapiroWilk";        label: qsTr("Shapiro-Wilk")     }
-		}
-	}
+	LD.LDAssessFit{ enabled: mainWindow.dataAvailable; includeShapiroWilk: true }
 }

--- a/inst/qml/LDlogistic.qml
+++ b/inst/qml/LDlogistic.qml
@@ -63,28 +63,5 @@ Form
 
 	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-	Section
-	{
-		title: qsTr("Assess Fit")
-		enabled: mainWindow.dataAvailable
-
-		Group
-		{
-			title: qsTr("Plots")
-			columns: 2
-			CheckBox{ name: "estPDF"; label: qsTr("Histogram vs. theoretical pdf") }
-			CheckBox{ name: "qqplot"; label: qsTr("Q-Q plot")                      }
-			CheckBox{ name: "estCDF"; label: qsTr("Empirical vs. theoretical cdf") }
-			CheckBox{ name: "ppplot"; label: qsTr("P-P plot")                      }
-		}
-
-		Group
-		{
-			title: qsTr("Statistics")
-			CheckBox{ name: "kolmogorovSmirnov";  label: qsTr("Kolmogorov-Smirnov")}
-			CheckBox{ name: "cramerVonMisses";    label: qsTr("Cramér–von Mises")  }
-			CheckBox{ name: "andersonDarling";    label: qsTr("Anderson-Darling")  }
-		}
-
-	}
+	LD.LDAssessFit { enabled: mainWindow.dataAvailable }
 }

--- a/inst/qml/LDlogistic.qml
+++ b/inst/qml/LDlogistic.qml
@@ -61,34 +61,8 @@ Form
 		enabled					: mainWindow.dataAvailable
 	}
 
-	Section
-	{
-		title: qsTr("Estimate Parameters")
-		enabled: mainWindow.dataAvailable
+	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-		Group
-		{
-			CheckBox{ name: "methodMLE";      label: qsTr("Maximum likelihood"); visible: true  }
-		}
-
-		Group
-		{
-			title: qsTr("Output")
-			CheckBox
-			{
-				name: "outputEstimates"; label: qsTr("Estimates"); checked: true
-				CheckBox{ name: "outputSE"; label: qsTr("Std. error"); checked: false }
-				CheckBox
-				{
-					name: "ciInterval"; label: qsTr("Confidence interval"); childrenOnSameRow: true
-					PercentField{ name: "ciIntervalInterval"; label: ""; defaultValue: 95 }
-				}
-			}
-
-			CheckBox{ name: "outputVarCov"; label: qsTr("Variance-covariance"); checked: false; visible: false }
-			CheckBox{ name: "outputCor";    label: qsTr("Correlation"); checked: false; visible: false }
-		}
-	}
 	Section
 	{
 		title: qsTr("Assess Fit")

--- a/inst/qml/LDlognormal.qml
+++ b/inst/qml/LDlognormal.qml
@@ -72,28 +72,5 @@ Form
 
 	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-	Section
-	{
-		title: qsTr("Assess Fit")
-		enabled: mainWindow.dataAvailable
-
-		Group
-		{
-			title: qsTr("Plots")
-			columns: 2
-			CheckBox{ name: "estPDF"; label: qsTr("Histogram vs. theoretical pdf") }
-			CheckBox{ name: "qqplot"; label: qsTr("Q-Q plot")                      }
-			CheckBox{ name: "estCDF"; label: qsTr("Empirical vs. theoretical cdf") }
-			CheckBox{ name: "ppplot"; label: qsTr("P-P plot")                      }
-		}
-
-		Group
-		{
-			title: qsTr("Statistics")
-			CheckBox{ name: "kolmogorovSmirnov";  label: qsTr("Kolmogorov-Smirnov")}
-			CheckBox{ name: "cramerVonMisses";    label: qsTr("Cramér–von Mises")  }
-			CheckBox{ name: "andersonDarling";    label: qsTr("Anderson-Darling")  }
-		}
-
-	}
+	LD.LDAssessFit { enabled: mainWindow.dataAvailable }
 }

--- a/inst/qml/LDlognormal.qml
+++ b/inst/qml/LDlognormal.qml
@@ -70,34 +70,8 @@ Form
 		enabled					: mainWindow.dataAvailable
 	}
 
-	Section
-	{
-		title: qsTr("Estimate Parameters")
-		enabled: mainWindow.dataAvailable
+	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-		Group
-		{
-			CheckBox{ name: "methodMLE";      label: qsTr("Maximum likelihood"); visible: true  }
-		}
-
-		Group
-		{
-			title: qsTr("Output")
-			CheckBox
-			{
-				name: "outputEstimates"; label: qsTr("Estimates"); checked: true
-				CheckBox{ name: "outputSE"; label: qsTr("Std. error"); checked: false }
-				CheckBox
-				{
-					name: "ciInterval"; label: qsTr("Confidence interval"); childrenOnSameRow: true
-					PercentField{ name: "ciIntervalInterval"; label: ""; defaultValue: 95 }
-				}
-			}
-
-			CheckBox{ name: "outputVarCov"; label: qsTr("Variance-covariance"); checked: false; visible: false }
-			CheckBox{ name: "outputCor";    label: qsTr("Correlation"); checked: false; visible: false }
-		}
-	}
 	Section
 	{
 		title: qsTr("Assess Fit")

--- a/inst/qml/LDnegbinomial.qml
+++ b/inst/qml/LDnegbinomial.qml
@@ -132,30 +132,5 @@ Form
 
 	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-	Section
-	{
-		title: qsTr("Assess Fit")
-		enabled: mainWindow.dataAvailable
-
-		Group
-		{
-			title: qsTr("Plots")
-			columns: 2
-			CheckBox{ name: "estPMF"; label: qsTr("Histogram vs. theoretical pmf") }
-			CheckBox{ name: "qqplot"; label: qsTr("Q-Q plot")                      }
-			CheckBox{ name: "estCDF"; label: qsTr("Empirical vs. theoretical cdf") }
-			CheckBox{ name: "ppplot"; label: qsTr("P-P plot")                      }
-		}
-
-		Group
-		{
-			title: qsTr("Statistics")
-			//CheckBox{ name: "kolmogorovSmirnov";  label: qsTr("Kolmogorov-Smirnov")}
-			//CheckBox{ name: "cramerVonMisses";    label: qsTr("Cramér–von Mises")  }
-			//CheckBox{ name: "andersonDarling";    label: qsTr("Anderson-Darling")  }
-			//CheckBox{ name: "shapiroWilk";        label: qsTr("Shapiro-Wilk")      }
-			CheckBox{ name: "chiSquare"; label: qsTr("Chi-square")}
-		}
-
-	}
+	LD.LDAssessFit { enabled: mainWindow.dataAvailable; distributionType: "counts" }
 }

--- a/inst/qml/LDnegbinomial.qml
+++ b/inst/qml/LDnegbinomial.qml
@@ -130,36 +130,8 @@ Form
 		enabled					: mainWindow.dataAvailable
 	}
 
-	Section
-	{
-		title: qsTr("Estimate Parameters")
-		enabled: mainWindow.dataAvailable
+	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-		Group
-		{
-			CheckBox{ name: "methodMLE";      label: qsTr("Maximum likelihood"); visible: true  }
-			CheckBox{ name: "methodMoments";  label: qsTr("Method of moments");  visible: false }
-			CheckBox{ name: "methodUnbiased"; label: qsTr("Unbiased estimator"); visible: false }
-		}
-
-		Group
-		{
-			title: qsTr("Output")
-			CheckBox
-			{
-				name: "outputEstimates"; label: qsTr("Estimates"); checked: true
-				CheckBox{ name: "outputSE"; label: qsTr("Std. error"); checked: false }
-				CheckBox
-				{
-					name: "ciInterval"; label: qsTr("Confidence interval"); childrenOnSameRow: true
-					PercentField{ name: "ciIntervalInterval"; label: ""; defaultValue: 95 }
-				}
-			}
-
-			CheckBox{ name: "outputVarCov"; label: qsTr("Variance-covariance"); checked: false; visible: false }
-			CheckBox{ name: "outputCor";    label: qsTr("Correlation"); checked: false; visible: false }
-		}
-	}
 	Section
 	{
 		title: qsTr("Assess Fit")

--- a/inst/qml/LDpoisson.qml
+++ b/inst/qml/LDpoisson.qml
@@ -103,36 +103,8 @@ Form
 		enabled					: mainWindow.dataAvailable
 	}
 
-	Section
-	{
-		title: qsTr("Estimate Parameters")
-		enabled: mainWindow.dataAvailable
+	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-		Group
-		{
-			CheckBox{ name: "methodMLE";      label: qsTr("Maximum likelihood"); visible: true  }
-			CheckBox{ name: "methodMoments";  label: qsTr("Method of moments");  visible: false }
-			CheckBox{ name: "methodUnbiased"; label: qsTr("Unbiased estimator"); visible: false }
-		}
-
-		Group
-		{
-			title: qsTr("Output")
-			CheckBox
-			{
-				name: "outputEstimates"; label: qsTr("Estimates"); checked: true
-				CheckBox{ name: "outputSE"; label: qsTr("Std. error"); checked: false }
-				CheckBox
-				{
-					name: "ciInterval"; label: qsTr("Confidence interval"); childrenOnSameRow: true
-					PercentField{ name: "ciIntervalInterval"; label: ""; defaultValue: 95 }
-				}
-			}
-
-			CheckBox{ name: "outputVarCov"; label: qsTr("Variance-covariance"); checked: false; visible: false }
-			CheckBox{ name: "outputCor";    label: qsTr("Correlation"); checked: false; visible: false }
-		}
-	}
 	Section
 	{
 		title: qsTr("Assess Fit")

--- a/inst/qml/LDpoisson.qml
+++ b/inst/qml/LDpoisson.qml
@@ -105,30 +105,5 @@ Form
 
 	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-	Section
-	{
-		title: qsTr("Assess Fit")
-		enabled: mainWindow.dataAvailable
-
-		Group
-		{
-			title: qsTr("Plots")
-			columns: 2
-			CheckBox{ name: "estPMF"; label: qsTr("Histogram vs. theoretical pmf") }
-			CheckBox{ name: "qqplot"; label: qsTr("Q-Q plot")                      }
-			CheckBox{ name: "estCDF"; label: qsTr("Empirical vs. theoretical cdf") }
-			CheckBox{ name: "ppplot"; label: qsTr("P-P plot")                      }
-		}
-
-		Group
-		{
-			title: qsTr("Statistics")
-			//CheckBox{ name: "kolmogorovSmirnov";  label: qsTr("Kolmogorov-Smirnov")}
-			//CheckBox{ name: "cramerVonMisses";    label: qsTr("Cramér–von Mises")  }
-			//CheckBox{ name: "andersonDarling";    label: qsTr("Anderson-Darling")  }
-			//CheckBox{ name: "shapiroWilk";        label: qsTr("Shapiro-Wilk")      }
-			CheckBox{ name: "chiSquare"; label: qsTr("Chi-square")}
-		}
-
-	}
+	LD.LDAssessFit { enabled: mainWindow.dataAvailable; distributionType: "counts" }
 }

--- a/inst/qml/LDt.qml
+++ b/inst/qml/LDt.qml
@@ -66,34 +66,8 @@ Form
 		enabled					: mainWindow.dataAvailable
 	}
 
-	Section
-	{
-		title: qsTr("Estimate Parameters")
-		enabled: mainWindow.dataAvailable
+	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-		Group
-		{
-			CheckBox{ name: "methodMLE";      label: qsTr("Maximum likelihood"); visible: true  }
-		}
-
-		Group
-		{
-			title: qsTr("Output")
-			CheckBox
-			{
-				name: "outputEstimates"; label: qsTr("Estimates"); checked: true
-				CheckBox{ name: "outputSE"; label: qsTr("Std. error"); checked: false }
-				CheckBox
-				{
-					name: "ciInterval"; label: qsTr("Confidence interval"); childrenOnSameRow: true
-					PercentField{ name: "ciIntervalInterval"; label: ""; defaultValue: 95 }
-				}
-			}
-
-			//CheckBox{ name: "outputVarCov"; label: qsTr("Variance-covariance"); checked: false; visible: false }
-			//CheckBox{ name: "outputCor";    label: qsTr("Correlation"); checked: false; visible: false }
-		}
-	}
 	Section
 	{
 		title: qsTr("Assess Fit")

--- a/inst/qml/LDt.qml
+++ b/inst/qml/LDt.qml
@@ -68,29 +68,5 @@ Form
 
 	LD.LDEstimateParameters { enabled: mainWindow.dataAvailable }
 
-	Section
-	{
-		title: qsTr("Assess Fit")
-		enabled: mainWindow.dataAvailable
-
-		Group
-		{
-			title: qsTr("Plots")
-			columns: 2
-			CheckBox{ name: "estPDF"; label: qsTr("Histogram vs. theoretical pdf") }
-			CheckBox{ name: "qqplot"; label: qsTr("Q-Q plot")                      }
-			CheckBox{ name: "estCDF"; label: qsTr("Empirical vs. theoretical cdf") }
-			CheckBox{ name: "ppplot"; label: qsTr("P-P plot")                      }
-		}
-
-		Group
-		{
-			title: qsTr("Statistics")
-			CheckBox{ name: "kolmogorovSmirnov";  label: qsTr("Kolmogorov-Smirnov")}
-			CheckBox{ name: "cramerVonMisses";    label: qsTr("Cramér–von Mises")  }
-			CheckBox{ name: "andersonDarling";    label: qsTr("Anderson-Darling")  }
-			//CheckBox{ name: "shapiroWilk";        label: qsTr("Shapiro-Wilk")      }
-		}
-
-	}
+	LD.LDAssessFit { enabled: mainWindow.dataAvailable }
 }

--- a/inst/qml/common/LDAssessFit.qml
+++ b/inst/qml/common/LDAssessFit.qml
@@ -1,0 +1,71 @@
+//
+// Copyright (C) 2013-2018 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+import QtQuick 2.8
+import QtQuick.Layouts 1.3
+import JASP.Controls 1.0
+
+Section
+{
+	property string	distributionType		: "continuous" // "counts" or "categorical"
+	property bool includeShapiroWilk		: false
+
+	title: enabled ? qsTr("Assess Fit") : qsTr("Assess Fit") + " - " + qsTr("[requires a loaded data set]")
+
+	Group
+	{
+		title: qsTr("Plots")
+		columns: 2
+		CheckBox{ name: distributionType == "continuous" ? "estPDF" : "estPMF"; label: distributionType == "continuous" ? qsTr("Histogram vs. theoretical pdf") : qsTr("Histogram vs. theoretical pmf") }
+		CheckBox{ name: "qqplot"; label: qsTr("Q-Q plot")                      }
+		CheckBox{ name: "estCDF"; label: qsTr("Empirical vs. theoretical cdf") }
+		CheckBox{ name: "ppplot"; label: qsTr("P-P plot")                      }
+	}
+
+	Loader
+	{
+		sourceComponent: distributionType == "continuous" ? continuous : ( distributionType == "counts" ? counts : categorical )
+		Component
+		{
+			id: continuous
+			Group
+			{
+				title: qsTr("Statistics")
+				CheckBox{ name: "kolmogorovSmirnov"; label: qsTr("Kolmogorov-Smirnov")}
+				CheckBox{ name: "cramerVonMisses";   label: qsTr("Cramér–von Mises")  }
+				CheckBox{ name: "andersonDarling";   label: qsTr("Anderson-Darling")  }
+				CheckBox{ name: "shapiroWilk";       label: qsTr("Shapiro-Wilk");	visible: includeShapiroWilk }
+			}
+		}
+
+		Component
+		{
+			id: counts
+			Group
+			{
+				title: qsTr("Statistics")
+				CheckBox{ name: "chiSquare"; label: qsTr("Chi-square")}
+			}
+		}
+
+		Component
+		{
+			id: categorical // for stuff like bernoulli / categorical dist (in future) we don't have any statistics implemented yet
+			Group{ }
+		}
+	}
+}

--- a/inst/qml/common/LDEstimateParameters.qml
+++ b/inst/qml/common/LDEstimateParameters.qml
@@ -1,0 +1,45 @@
+//
+// Copyright (C) 2013-2018 University of Amsterdam
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public
+// License along with this program.  If not, see
+// <http://www.gnu.org/licenses/>.
+//
+import QtQuick 2.8
+import QtQuick.Layouts 1.3
+import JASP.Controls 1.0
+
+Section
+{
+	title: enabled ? qsTr("Estimate Parameters") : qsTr("Estimate Parameters") + " - " + qsTr("[requires a loaded data set]")
+
+	Group
+	{
+		CheckBox{ name: "methodMLE";      label: qsTr("Maximum likelihood"); visible: true  }
+	}
+
+	Group
+	{
+		title: qsTr("Output")
+		CheckBox
+		{
+			name: "outputEstimates"; label: qsTr("Estimates"); checked: true
+			CheckBox{ name: "outputSE"; label: qsTr("Std. error"); checked: false }
+			CheckBox
+			{
+				name: "ciInterval"; label: qsTr("Confidence interval"); childrenOnSameRow: true
+				PercentField{ name: "ciIntervalInterval"; label: ""; defaultValue: 95 }
+			}
+		}
+	}
+}

--- a/inst/qml/common/LDGenerateDisplayData.qml
+++ b/inst/qml/common/LDGenerateDisplayData.qml
@@ -30,7 +30,7 @@ Section
 	property bool	allowOnlyScaleColumns		: true
 	property bool	suggestScaleColumns			: false
 
-	title: qsTr("Generate and Display Data")
+	title: enabled ? qsTr("Generate and Display Data") : qsTr("Generate and Display Data") + " - " + qsTr("[requires a loaded data set]")
 	Group
 	{
 		Layout.columnSpan: 2

--- a/tests/testthat/test-ldbernoulli.R
+++ b/tests/testthat/test-ldbernoulli.R
@@ -4,6 +4,7 @@ options <- jaspTools::analysisOptions("LDbernoulli")
 options$.meta <- list(newVariableName = list(containsColumn = TRUE), variable = list(
   containsColumn = TRUE))
 options$ciInterval <- TRUE
+options$ciIntervalInterval <- 0.95
 options$estCDF <- TRUE
 options$estPMF <- TRUE
 options$explanatoryText <- TRUE
@@ -11,11 +12,13 @@ options$histogram <- TRUE
 options$max <- 0
 options$methodMLE <- TRUE
 options$newVariableName <- ""
+options$outputEstimates <- TRUE
 options$outputSE <- TRUE
 options$parsSupportMoments <- TRUE
 options$plotCMF <- TRUE
 options$ppplot <- TRUE
 options$summary <- TRUE
+options$qqplot <- TRUE
 options$variable <- "Bern10(p=0.5)"
 set.seed(1)
 results <- jaspTools::runAnalysis("LDbernoulli", "Distributions.csv", options)

--- a/tests/testthat/test-ldbeta.R
+++ b/tests/testthat/test-ldbeta.R
@@ -7,6 +7,7 @@ options$alpha <- 3
 options$andersonDarling <- TRUE
 options$beta <- 2
 options$ciInterval <- TRUE
+options$ciIntervalInterval <- 0.95
 options$cramerVonMisses <- TRUE
 options$ecdf <- TRUE
 options$estCDF <- TRUE
@@ -19,6 +20,7 @@ options$kolmogorovSmirnov <- TRUE
 options$methodMLE <- TRUE
 options$moments <- TRUE
 options$newVariableName <- ""
+options$outputEstimates <- TRUE
 options$outputSE <- TRUE
 options$parsSupportMoments <- TRUE
 options$plotCDF <- TRUE

--- a/tests/testthat/test-ldbinomial.R
+++ b/tests/testthat/test-ldbinomial.R
@@ -5,6 +5,7 @@ options$.meta <- list(newVariableName = list(containsColumn = TRUE), variable = 
   containsColumn = TRUE))
 options$chiSquare <- TRUE
 options$ciInterval <- TRUE
+options$ciIntervalInterval <- 0.95
 options$ecdf <- TRUE
 options$estCDF <- TRUE
 options$estPMF <- TRUE
@@ -18,6 +19,7 @@ options$methodMLE <- TRUE
 options$min <- 3
 options$moments <- TRUE
 options$newVariableName <- ""
+options$outputEstimates <- TRUE
 options$outputSE <- TRUE
 options$parsSupportMoments <- TRUE
 options$plotCMF <- TRUE

--- a/tests/testthat/test-ldchisq.R
+++ b/tests/testthat/test-ldchisq.R
@@ -6,8 +6,10 @@ options$parsSupportMoments <- TRUE
 options$plotCDF <- TRUE
 options$plotQF <- TRUE
 options$methodMLE <- TRUE
+options$outputEstimates <- TRUE
 options$outputSE <- TRUE
 options$ciInterval <- TRUE
+options$ciIntervalInterval <- 0.95
 options$estPDF <- TRUE
 options$qqplot <- TRUE
 options$estCDF <- TRUE

--- a/tests/testthat/test-ldexponential.R
+++ b/tests/testthat/test-ldexponential.R
@@ -5,6 +5,7 @@ options$.meta <- list(newVariableName = list(containsColumn = TRUE), variable = 
   containsColumn = TRUE))
 options$andersonDarling <- TRUE
 options$ciInterval <- TRUE
+options$ciIntervalInterval <- 0.95
 options$cramerVonMisses <- TRUE
 options$ecdf <- TRUE
 options$estCDF <- TRUE
@@ -17,6 +18,7 @@ options$kolmogorovSmirnov <- TRUE
 options$methodMLE <- TRUE
 options$moments <- TRUE
 options$newVariableName <- ""
+options$outputEstimates <- TRUE
 options$outputSE <- TRUE
 options$parsSupportMoments <- TRUE
 options$plotCDF <- TRUE

--- a/tests/testthat/test-ldf.R
+++ b/tests/testthat/test-ldf.R
@@ -5,6 +5,7 @@ options$.meta <- list(newVariableName = list(containsColumn = TRUE), variable = 
   containsColumn = TRUE))
 options$andersonDarling <- TRUE
 options$ciInterval <- TRUE
+options$ciIntervalInterval <- 0.95
 options$cramerVonMisses <- TRUE
 options$ecdf <- TRUE
 options$estCDF <- TRUE
@@ -17,6 +18,7 @@ options$kolmogorovSmirnov <- TRUE
 options$methodMLE <- TRUE
 options$moments <- TRUE
 options$newVariableName <- ""
+options$outputEstimates <- TRUE
 options$outputSE <- TRUE
 options$parsSupportMoments <- TRUE
 options$plotCDF <- TRUE

--- a/tests/testthat/test-ldgamma.R
+++ b/tests/testthat/test-ldgamma.R
@@ -4,6 +4,7 @@ options <- jaspTools::analysisOptions("LDgamma")
 options$.meta <- list(newVariableName = list(containsColumn = TRUE), variable = list(
   containsColumn = TRUE))
 options$andersonDarling <- TRUE
+options$ciIntervalInterval <- 0.95
 options$ciInterval <- TRUE
 options$cramerVonMisses <- TRUE
 options$ecdf <- TRUE
@@ -18,6 +19,7 @@ options$kolmogorovSmirnov <- TRUE
 options$methodMLE <- TRUE
 options$moments <- TRUE
 options$newVariableName <- ""
+options$outputEstimates <- TRUE
 options$outputSE <- TRUE
 options$parsSupportMoments <- TRUE
 options$plotCDF <- TRUE

--- a/tests/testthat/test-ldgammainverse.R
+++ b/tests/testthat/test-ldgammainverse.R
@@ -5,6 +5,7 @@ options$.meta <- list(newVariableName = list(containsColumn = TRUE), variable = 
   containsColumn = TRUE))
 options$andersonDarling <- TRUE
 options$ciInterval <- TRUE
+options$ciIntervalInterval <- 0.95
 options$cramerVonMisses <- TRUE
 options$ecdf <- TRUE
 options$estCDF <- TRUE
@@ -18,6 +19,7 @@ options$kolmogorovSmirnov <- TRUE
 options$methodMLE <- TRUE
 options$moments <- TRUE
 options$newVariableName <- ""
+options$outputEstimates <- TRUE
 options$outputSE <- TRUE
 options$parsSupportMoments <- TRUE
 options$plotCDF <- TRUE

--- a/tests/testthat/test-ldgaussianunivariate.R
+++ b/tests/testthat/test-ldgaussianunivariate.R
@@ -5,6 +5,7 @@ options$.meta <- list(newVariableName = list(containsColumn = TRUE), variable = 
   containsColumn = TRUE))
 options$andersonDarling <- TRUE
 options$ciInterval <- TRUE
+options$ciIntervalInterval <- 0.95
 options$cramerVonMisses <- TRUE
 options$ecdf <- TRUE
 options$estCDF <- TRUE
@@ -18,6 +19,7 @@ options$methodMLE <- TRUE
 options$moments <- TRUE
 options$momentsUpTo <- 10
 options$newVariableName <- ""
+options$outputEstimates <- TRUE
 options$outputSE <- TRUE
 options$parsSupportMoments <- TRUE
 options$plotCDF <- TRUE

--- a/tests/testthat/test-ldlogistic.R
+++ b/tests/testthat/test-ldlogistic.R
@@ -3,6 +3,7 @@ context("Discover Distributions - Logistic")
 options <- jaspTools::analysisOptions("LDlogistic")
 options$andersonDarling <- TRUE
 options$ciInterval <- TRUE
+options$ciIntervalInterval <- 0.95
 options$cramerVonMisses <- TRUE
 options$estCDF <- TRUE
 options$estPDF <- TRUE
@@ -12,6 +13,7 @@ options$histogram <- FALSE
 options$kolmogorovSmirnov <- TRUE
 options$methodMLE <- TRUE
 options$newVariableName <- ""
+options$outputEstimates <- TRUE
 options$outputSE <- TRUE
 options$parsSupportMoments <- TRUE
 options$plotCDF <- TRUE

--- a/tests/testthat/test-ldlognormal.R
+++ b/tests/testthat/test-ldlognormal.R
@@ -3,6 +3,7 @@ context("Discover Distributions - Log Normal")
 options <- jaspTools::analysisOptions("LDlognormal")
 options$andersonDarling <- TRUE
 options$ciInterval <- TRUE
+options$ciIntervalInterval <- 0.95
 options$cramerVonMisses <- TRUE
 options$estCDF <- TRUE
 options$estPDF <- TRUE
@@ -12,6 +13,7 @@ options$histogram <- FALSE
 options$kolmogorovSmirnov <- TRUE
 options$methodMLE <- TRUE
 options$newVariableName <- ""
+options$outputEstimates <- TRUE
 options$outputSE <- TRUE
 options$parsSupportMoments <- TRUE
 options$plotCDF <- TRUE

--- a/tests/testthat/test-ldnegbinomial.R
+++ b/tests/testthat/test-ldnegbinomial.R
@@ -5,6 +5,7 @@ options$.meta <- list(newVariableName = list(containsColumn = TRUE), variable = 
   containsColumn = TRUE))
 options$chiSquare <- TRUE
 options$ciInterval <- TRUE
+options$ciIntervalInterval <- 0.95
 options$ecdf <- TRUE
 options$estCDF <- TRUE
 options$estPMF <- TRUE
@@ -16,6 +17,7 @@ options$methodMLE <- TRUE
 options$min <- 2
 options$moments <- TRUE
 options$newVariableName <- ""
+options$outputEstimates <- TRUE
 options$outputSE <- TRUE
 options$par <- 0.5
 options$parsSupportMoments <- TRUE

--- a/tests/testthat/test-ldpoisson.R
+++ b/tests/testthat/test-ldpoisson.R
@@ -5,6 +5,7 @@ options$.meta <- list(newVariableName = list(containsColumn = TRUE), variable = 
   containsColumn = TRUE))
 options$chiSquare <- TRUE
 options$ciInterval <- TRUE
+options$ciIntervalInterval <- 0.95
 options$ecdf <- TRUE
 options$estCDF <- TRUE
 options$estPMF <- TRUE
@@ -17,6 +18,7 @@ options$methodMLE <- TRUE
 options$min <- 2
 options$moments <- TRUE
 options$newVariableName <- ""
+options$outputEstimates <- TRUE
 options$outputSE <- TRUE
 options$parsSupportMoments <- TRUE
 options$plotCMF <- TRUE

--- a/tests/testthat/test-ldt.R
+++ b/tests/testthat/test-ldt.R
@@ -5,6 +5,7 @@ options$.meta <- list(newVariableName = list(containsColumn = TRUE), variable = 
   containsColumn = TRUE))
 options$andersonDarling <- TRUE
 options$ciInterval <- TRUE
+options$ciIntervalInterval <- 0.95
 options$cramerVonMisses <- TRUE
 options$ecdf <- TRUE
 options$estCDF <- TRUE
@@ -16,6 +17,7 @@ options$kolmogorovSmirnov <- TRUE
 options$methodMLE <- TRUE
 options$moments <- TRUE
 options$newVariableName <- ""
+options$outputEstimates <- TRUE
 options$outputSE <- TRUE
 options$ppplot <- TRUE
 options$qqplot <- TRUE


### PR DESCRIPTION
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1005
Fixes https://github.com/jasp-stats/jasp-test-release/issues/1013

Reduces a lot of duplication in the qml files (I hope @vandenman will like that)

Tomorrow, I will copy these changes to a PR for `jasp-desktop/stable`.