### PR TITLE
use reuseable workflow and fix a test that failed on R-4.2.0

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,36 +1,18 @@
-on: [push, pull_request]
+on:
+  push:
+    paths: ['**.R', 'tests/**', '**.Rd', '**.c', '**.cpp', '**.h', '**.hpp', 'DESCRIPTION', 'NAMESPACE', 'MAKEVARS', 'MAKEVARS.win', '**.yml']
+  pull_request:
+    paths: ['**.R', 'tests/**', '**.Rd', '**.c', '**.cpp', '**.h', '**.hpp', 'DESCRIPTION', 'NAMESPACE', 'MAKEVARS', 'MAKEVARS.win']
+  schedule:
+    - cron:  '13 12 * * 1-5'
 
 name: unit-tests
 
 jobs:
+
   unit-tests:
-    runs-on: ${{ matrix.config.os }}
 
-    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
-
-    strategy:
-      fail-fast: false
-      matrix:
-        config:
-          - {os: windows-latest, r: "4.1.0"}
-          - {os: macOS-latest,   r: "4.1.0"}
-          - {os: ubuntu-20.04,   r: "4.1.0"}
-
-    env:
-      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
-      R_REMOTES_UPGRADE: never
-      VDIFFR_RUN_TESTS: true
-      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: r-lib/actions/setup-r@master
-        with:
-          r-version: ${{ matrix.config.r }}
-
-      - uses: jasp-stats/jasp-actions/setup-test-env@master
-
-      - name: Run unit tests
-        run: source("tests/testthat.R")
-        shell: Rscript {0}
+    uses: jasp-stats/jasp-actions/.github/workflows/unittests.yml@master
+    with:
+      needs_JAGS:   false
+      needs_igraph: false

--- a/R/commonDiscoverDistributions.R
+++ b/R/commonDiscoverDistributions.R
@@ -1221,8 +1221,8 @@ gettextf <- function(fmt, ..., domain = NULL)  {
     # calculate position of the geom_text
     datShown <- datHigh[datHigh$x %in% dat$x, ]
     if(ncol(datShown) > 0) {
-      x <- datShown$x[which.max(datShown$pmf)]
-      y <- datShown$pmf[which.max(datShown$pmf)] + 0.1 * max(dat$y)
+      x <- datShown$x[which.max(round(datShown$pmf, 3))]
+      y <- datShown$pmf[which.max(round(datShown$pmf, 3))] + 0.1 * max(dat$y)
     } else{ # the entire highlight region is outside of displayed range
       x <- NA
       y <- NA


### PR DESCRIPTION
Brings in https://github.com/jasp-stats/jaspDistributions/pull/70 and fixes the failing test on R-4.2.0. The test failed due to a precision issue, the fix is not elegant but works, this functionality will be improved anyways with the upcoming refactor to the module.

Follow the run at https://github.com/Kucharssim/jaspDistributions/actions/runs/2275129544